### PR TITLE
helper for website ID <-> domain/slug

### DIFF
--- a/aldryn_client/api_requests.py
+++ b/aldryn_client/api_requests.py
@@ -35,6 +35,9 @@ class APIRequest(object):
         self.data = data or {}
         self.files = files or {}
 
+    def __call__(self, *args, **kwargs):
+        return self.request(*args, **kwargs)
+
     def get_url(self):
         return self.url.format(**self.url_kwargs)
 

--- a/aldryn_client/api_requests.py
+++ b/aldryn_client/api_requests.py
@@ -94,3 +94,17 @@ class UploadAddonRequest(TextResponse, APIRequest):
 class UploadBoilerplateRequest(TextResponse, APIRequest):
     url = '/api/v1/boilerplates/'
     method = 'POST'
+
+
+class SlugToIDRequest(APIRequest):
+    url = '/api/v1/slug-to-id/{website_slug}/'
+
+    def echo(self, response):
+        return response.json().get('id')
+
+
+class IDToSlugRequest(APIRequest):
+    url = '/api/v1/id-to-slug/{website_id}/'
+
+    def echo(self, response):
+        return response.json().get('slug')

--- a/aldryn_client/cli.py
+++ b/aldryn_client/cli.py
@@ -71,12 +71,13 @@ def project_list(obj):
 
     projects = [(
         project_data['id'],
+        project_data['domain'],
         project_data['name'],
         organisations.get(project_data['organisation_id'], 'Personal'),
     ) for project_data in data['websites']]
 
-    header = ['ID', 'Name', 'Organisation']
-    click.echo(table(projects, header))
+    header = ['#', 'ID', 'Name', 'Organisation']
+    click.echo_via_pager(table(projects, header))
 
 
 @project.command(name='info')

--- a/aldryn_client/cli.py
+++ b/aldryn_client/cli.py
@@ -76,7 +76,7 @@ def project_list(obj):
         organisations.get(project_data['organisation_id'], 'Personal'),
     ) for project_data in data['websites']]
 
-    header = ['#', 'ID', 'Name', 'Organisation']
+    header = ['ID', 'Slug', 'Name', 'Organisation']
     click.echo_via_pager(table(projects, header))
 
 

--- a/aldryn_client/cloud.py
+++ b/aldryn_client/cloud.py
@@ -85,6 +85,20 @@ class CloudClient(object):
         )
         return request.request()
 
+    def get_website_id_for_slug(self, slug):
+        request = api_requests.SlugToIDRequest(
+            self.session,
+            url_kwargs={'website_slug': slug}
+        )
+        return request.request()
+
+    def get_website_slug_for_id(self, website_id):
+        request = api_requests.IDToSlugRequest(
+            self.session,
+            url_kwargs={'website_id': website_id}
+        )
+        return request.request()
+
 
 class WritableNetRC(netrc):
     def __init__(self, *args, **kwargs):

--- a/aldryn_client/cloud.py
+++ b/aldryn_client/cloud.py
@@ -42,7 +42,7 @@ class CloudClient(object):
             data={'token': token}
         )
 
-        user_data = request.request()
+        user_data = request()
 
         first_name = user_data.get('first_name')
         last_name = user_data.get('last_name')
@@ -62,42 +62,42 @@ class CloudClient(object):
 
     def get_projects(self):
         request = api_requests.ProjectListRequest(self.session)
-        return request.request()
+        return request()
 
     def get_project(self, website_id):
         request = api_requests.ProjectDetailRequest(
             self.session,
             url_kwargs={'website_id': website_id},
         )
-        return request.request()
+        return request()
 
     def upload_addon(self, archive_obj):
         request = api_requests.UploadAddonRequest(
             self.session,
             files={'app': archive_obj}
         )
-        return request.request()
+        return request()
 
     def upload_boilerplate(self, archive_obj):
         request = api_requests.UploadBoilerplateRequest(
             self.session,
             files={'boilerplate': archive_obj}
         )
-        return request.request()
+        return request()
 
     def get_website_id_for_slug(self, slug):
         request = api_requests.SlugToIDRequest(
             self.session,
             url_kwargs={'website_slug': slug}
         )
-        return request.request()
+        return request()
 
     def get_website_slug_for_id(self, website_id):
         request = api_requests.IDToSlugRequest(
             self.session,
             url_kwargs={'website_id': website_id}
         )
-        return request.request()
+        return request()
 
 
 class WritableNetRC(netrc):


### PR DESCRIPTION
Allows traversal through the control panel api from website ``domain / slug`` to ``id`` and vice versa.

Also includes an update in the project list view + adds a pager there.