### PR TITLE
localdev: develop addon

### DIFF
--- a/aldryn_client/cli.py
+++ b/aldryn_client/cli.py
@@ -7,7 +7,7 @@ except ImportError:
 
 import click
 
-from .localdev.main import create_workspace
+from .localdev.main import create_workspace, develop_package
 from .cloud import CloudClient
 from .check_system import check_requirements
 from .utils import hr, table
@@ -95,7 +95,14 @@ def project_info(obj, project_id):
 @click.option('-p', '--path', default='.', help='install project to path', type=click.Path(writable=True, readable=True))
 @click.pass_obj
 def project_workon(obj, project_id, path):
-    click.echo(create_workspace(obj, project_id, path))
+    create_workspace(obj, project_id, path)
+
+
+@project.command(name='develop')
+@click.argument('package', 'package')
+@click.pass_obj
+def project_develop(obj, package,):
+    develop_package(package)
 
 
 @cli.group()

--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -1,0 +1,28 @@
+import os
+
+import click
+
+
+def get_project_home():
+    """
+    find project root by traversing up the tree looking for
+    the '.aldryn' file
+    """
+    previous_path = None
+    current_path = os.getcwd()
+
+    # loop until we're at the root of the volume
+    while current_path != previous_path:
+
+        # check if '.aldryn' file exists in current directory
+        if os.path.exists(os.path.join(current_path, '.aldryn')):
+            return current_path
+
+        # traversing up the tree
+        previous_path = current_path
+        current_path = os.path.abspath(os.path.join(current_path, os.pardir))
+
+    raise click.ClickException(
+        "Aldryn project file '.aldryn' could not be found! Please make sure "
+        "you're in an Aldryn project folder and the file exists."
+    )


### PR DESCRIPTION
Enables the user to run ``aldryn project develop aldryn-newsblog`` and work on the package's source within the docker container.