### PR TITLE
windows fixes

### DIFF
--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -63,7 +63,29 @@ def get_docker_compose_cmd(path):
 
 
 def ensure_windows_docker_compose_file_exists(path):
-    """ I'm sorry """
+    """
+    Unfortunately, docker-compose is not yet officially released
+     for Windows There's still some rough edges, and volume
+     configuration is one. There's also some open issues in
+     boot2docker for windows which makes things difficult.
+
+    We have to change the volume specifications to a very specific
+     format:
+
+     - absolute paths: relative one's are not yet supported
+     - currently only works if the project is running on the C:\ drive
+     - unix style paths: need to replace '\' with '/'
+     - paths have to start with /c/ instead of C:\ otherwise
+        docker-compose gets confused because they use : as separation
+
+    Example:
+      unix format:  .:/app:rw
+      cwd:          C:\Users\aldryn\acme-portfolio
+      windows:     /c/Users/aldryn/acme-portfolio:/app:rw
+
+    Hope that's all. And of course, I'm sorry.
+    """
+
     windows_path = os.path.join(path, WINDOWS_DOCKER_COMPOSE_FILENAME)
     if os.path.isfile(windows_path):
         return

--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -46,7 +46,7 @@ WINDOWS_DOCKER_COMPOSE_FILENAME = 'docker-compose-windows.yml'
 
 
 def get_docker_compose_cmd(path):
-    if is_windows():
+    if not is_windows():
         docker_compose_filename = WINDOWS_DOCKER_COMPOSE_FILENAME
         ensure_windows_docker_compose_file_exists(path)
     else:
@@ -98,29 +98,29 @@ def ensure_windows_docker_compose_file_exists(path):
         config = yaml.load(fh)
 
     for component, sections in config.iteritems():
-            if 'volumes' not in sections:
-                continue
-            volumes = []
-            for volume in sections['volumes']:
-                parts = volume.split(':')
-                if len(parts) == 2:
-                    old_host, container = parts
-                    mode = None
-                else:
-                    old_host, container, mode = parts
+        if 'volumes' not in sections:
+            continue
+        volumes = []
+        for volume in sections['volumes']:
+            parts = volume.split(':')
+            if len(parts) == 2:
+                old_host, container = parts
+                mode = None
+            else:
+                old_host, container, mode = parts
 
-                # assuming relative path's for old_host
-                new_host = os.path.abspath(os.path.join(path, old_host))
-                # replace C:\ with /c/, because, docker on windows
-                new_host = new_host.replace('C:\\', '/c/')
-                # change to unix paths
-                new_host = new_host.replace('\\', '/')
-                new_volume = [new_host, container]
-                if mode:
-                    new_volume.append(mode)
-                volumes.append(':'.join(new_volume))
+            # assuming relative path's for old_host
+            new_host = os.path.abspath(os.path.join(path, old_host))
+            # replace C:\ with /c/, because, docker on windows
+            new_host = new_host.replace('C:\\', '/c/')
+            # change to unix paths
+            new_host = new_host.replace('\\', '/')
+            new_volume = [new_host, container]
+            if mode:
+                new_volume.append(mode)
+            volumes.append(':'.join(new_volume))
 
-            config[component]['volumes'] = volumes
+        config[component]['volumes'] = volumes
 
     with open(windows_path, 'w+') as fh:
         yaml.dump(config, fh)

--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -1,9 +1,11 @@
 import json
+import sys
 import os
 
 import click
+import yaml
 
-from ..utils import check_output
+from ..utils import check_output, is_windows
 from .. import settings
 
 
@@ -39,15 +41,67 @@ def get_project_home(path=None):
     )
 
 
+UNIX_DOCKER_COMPOSE_FILENAME = 'docker-compose.yml'
+WINDOWS_DOCKER_COMPOSE_FILENAME = 'docker-compose-windows.yml'
+
+
 def get_docker_compose_cmd(path):
+    if is_windows():
+        docker_compose_filename = WINDOWS_DOCKER_COMPOSE_FILENAME
+        ensure_windows_docker_compose_file_exists(path)
+    else:
+        docker_compose_filename = UNIX_DOCKER_COMPOSE_FILENAME
+
     docker_compose_base = [
-        'docker-compose', '-f', os.path.join(path, 'docker-compose.yml')
+        'docker-compose', '-f', os.path.join(path, docker_compose_filename)
     ]
 
     def docker_compose(*commands):
         return docker_compose_base + [cmd for cmd in commands]
 
     return docker_compose
+
+
+def ensure_windows_docker_compose_file_exists(path):
+    """ I'm sorry """
+    windows_path = os.path.join(path, WINDOWS_DOCKER_COMPOSE_FILENAME)
+    if os.path.isfile(windows_path):
+        return
+
+    unix_path = os.path.join(path, UNIX_DOCKER_COMPOSE_FILENAME)
+    if not os.path.isfile(unix_path):
+        exit('docker-compose.yml not found')
+
+    with open(unix_path, 'r') as fh:
+        config = yaml.load(fh)
+
+    for component, sections in config.iteritems():
+            if 'volumes' not in sections:
+                continue
+            volumes = []
+            for volume in sections['volumes']:
+                parts = volume.split(':')
+                if len(parts) == 2:
+                    old_host, container = parts
+                    mode = None
+                else:
+                    old_host, container, mode = parts
+
+                # assuming relative path's for old_host
+                new_host = os.path.abspath(os.path.join(path, old_host))
+                # replace C:\ with /c/, because, docker on windows
+                new_host = new_host.replace('C:\\', '/c/')
+                # change to unix paths
+                new_host = new_host.replace('\\', '/')
+                new_volume = [new_host, container]
+                if mode:
+                    new_volume.append(mode)
+                volumes.append(':'.join(new_volume))
+
+            config[component]['volumes'] = volumes
+
+    with open(windows_path, 'w+') as fh:
+        yaml.dump(config, fh)
 
 
 def get_db_container_id(path):

--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -88,7 +88,7 @@ def execute(func, *popenargs, **kwargs):
     if kwargs.pop('silent', False):
         if 'stdout' not in kwargs:
             kwargs['stdout'] = open(os.devnull, 'w')
-            if not sys.platform == 'win32':
+            if not is_windows():
                 # close file descriptor devnull after exit
                 # unfortunately, close_fds is not supported on Windows
                 # platforms if you redirect stdin/stdout/stderr

--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import subprocess
 import tarfile
 import tempfile
@@ -11,7 +10,7 @@ import click
 from tabulate import tabulate
 
 
-def hr(char='─', width=None, **kwargs):
+def hr(char='-', width=None, **kwargs):
     if width is None:
         width = click.get_terminal_size()[0]
     click.secho(char * width, **kwargs)
@@ -89,8 +88,13 @@ def execute(func, *popenargs, **kwargs):
     if kwargs.pop('silent', False):
         if 'stdout' not in kwargs:
             kwargs['stdout'] = open(os.devnull, 'w')
-            # close file descriptor devnull after exit
-            kwargs['close_fds'] = True
+            if not sys.platform == 'win32':
+                # close file descriptor devnull after exit
+                # unfortunately, close_fds is not supported on Windows
+                # platforms if you redirect stdin/stdout/stderr
+                # => http://svn.python.org/projects/python/
+                #    branches/py3k/Lib/subprocess.py
+                kwargs['close_fds'] = True
         if 'stderr' not in kwargs:
             kwargs['stderr'] = subprocess.STDOUT
     try:
@@ -142,3 +146,7 @@ def get_dashboard_url(client):
 def get_project_cheatsheet_url(client):
     dashboard = get_dashboard_url(client)
     return urljoin(dashboard, 'local-development/')
+
+
+def is_windows():
+    return sys.platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ INSTALL_REQUIRES = [
     'click',
     'requests',
     'tabulate',
+    'pyyaml',
 ]
 
 


### PR DESCRIPTION
# fixing windows support
* replace wider (unicode) '-' character with standard one '-'
* pull-db: make sure to wait until it's _really_ done
* skip subprocess#close_fds on windows since it's not supported
* ~~change the way we run the migrate script to not have issues with bash scripts edited with windows and their newline system (see https://www.google.ch/search?q=bin+bash+%5Em+bad+interpreter)~~
* add helper to convert unix-style volume configuration in docker-compose.yml to windows-understandable format