### PR TITLE
use yaml.safe_dump() to avoid yml type discriptors

### DIFF
--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -123,7 +123,7 @@ def ensure_windows_docker_compose_file_exists(path):
         config[component]['volumes'] = volumes
 
     with open(windows_path, 'w+') as fh:
-        yaml.dump(config, fh)
+        yaml.safe_dump(config, fh)
 
 
 def get_db_container_id(path):

--- a/aldryn_client/localdev/utils.py
+++ b/aldryn_client/localdev/utils.py
@@ -92,7 +92,8 @@ def ensure_windows_docker_compose_file_exists(path):
 
     unix_path = os.path.join(path, UNIX_DOCKER_COMPOSE_FILENAME)
     if not os.path.isfile(unix_path):
-        exit('docker-compose.yml not found')
+        # TODO: use correct exit from click
+        sys.exit('docker-compose.yml not found at {}'.format(unix_path))
 
     with open(unix_path, 'r') as fh:
         config = yaml.load(fh)


### PR DESCRIPTION
loading fails because some implementations of yaml.dump() return
string in this format:
   !!python/unicode 'abc'

safe_dump() *should* avoid this