### PR TITLE
Encode DB dump log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,15 @@
 Changelog
 =========
 
+Next release
+------------
+
+* Encode database dump log into utf-8 before writing the file.
+
+
 2.0.2 (2015-10-21)
 ------------------
+
 * Fix for local directory permissions on Linux (https://github.com/aldryn/aldryn-client/pull/98)
 * Don't automatically delete a project after a failed setup.
   Users are prompted to delete the project if trying to set it up again.
@@ -10,10 +17,12 @@ Changelog
 
 2.0.1 (2015-10-14)
 ------------------
+
 * Change push database / media confirmation texts to represent the actual state
 
 
 2.0 (2015-10-13)
 ----------------
+
 * Brand new client, entirely rewritten from scratch and now completely dockerized
 * Ready for the new Aldryn baseproject (v3)

--- a/aldryn_client/api_requests.py
+++ b/aldryn_client/api_requests.py
@@ -203,7 +203,7 @@ class UploadDBRequest(TextResponse, APIRequest):
             click.secho('Database dump successfully uploaded')
         if response.status_code == requests.codes.bad_request:
             try:
-                db_log = response.json()['message']
+                db_log = response.json()['message'].encode('utf-8')
             except (TypeError, IndexError):
                 pass
             else:

--- a/aldryn_client/localdev/main.py
+++ b/aldryn_client/localdev/main.py
@@ -322,7 +322,7 @@ def upload_media(client):
             stage,
         ),
     )
-    click.secho('Conmpressing local media folder...')
+    click.secho('Compressing local media folder...')
     with tarfile.open(archive_path, mode='w:gz') as tar:
         media_dir = os.path.join(project_home, 'data', 'media')
         for item in os.listdir(media_dir):


### PR DESCRIPTION
If DB dump log contains non-ascii characters writing it to the local log file would fail.

* Encode database dump log into utf-8 before writing the file
* Fix typo in upload_media() message
* Update changelog