### PR TITLE
Properly calculate directory size while uploading media files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Next release
+------------
+
+* Fix ``media`` directory size calculation during ``aldryn project push media``.
+
+
 2.0.4 (2015-11-05)
 ------------------
 

--- a/aldryn_client/localdev/main.py
+++ b/aldryn_client/localdev/main.py
@@ -10,7 +10,7 @@ import click
 import requests
 import shutil
 
-from ..utils import check_call, check_output, is_windows, pretty_size
+from ..utils import check_call, check_output, is_windows, pretty_size, get_size
 from ..cloud import get_aldryn_host
 from .. import settings
 from . import utils
@@ -451,7 +451,7 @@ def push_media(client):
                 continue
             file_path = os.path.join(media_dir, item)
             tar.add(file_path, arcname=item)
-            uncompressed_size += os.path.getsize(file_path)
+            uncompressed_size += get_size(file_path)
         file_count = len(tar.getmembers())
     compress_time = int(time() - start_compression)
     click.echo(

--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -172,3 +172,24 @@ def pretty_size(num):
         return '0 bytes'
     elif num == 1:
         return '1 byte'
+
+
+def get_size(start_path):
+    """
+    Get size of the file or directory specified by start_path in bytes.
+
+    If ``start_path`` points to a file - get it's size, if it points to a
+    directory - calculate total size of all the files within it
+    (including subdirectories).
+    """
+    # http://stackoverflow.com/a/1392549/176490
+
+    if os.path.isfile(start_path):
+        return os.path.getsize(start_path)
+
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(start_path):
+        for filename in filenames:
+            fp = os.path.join(dirpath, filename)
+            total_size += os.path.getsize(fp)
+    return total_size


### PR DESCRIPTION
Currently only the directory (inode) size is calculated.

This adds an utility method that uses ``os.walk`` to calculate the size of all the files within directory. 