### PR TITLE
Fixed Python 2to3 issue reguarding zip() creates list object in Python 2

### DIFF
--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -159,10 +159,10 @@ def is_linux():
     return sys.platform.startswith('linux')
 
 
-unit_list = zip(
+unit_list = list(zip(
         ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'],
         [0, 0, 1, 2, 2, 2],
-)
+))
 
 
 def pretty_size(num):


### PR DESCRIPTION
and zip object in Python 3.

Directly before "def pretty_size(num):" the var unit_list is created as
line 162:unit_list = zip(
line 163:        ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'],
line 164:        [0, 0, 1, 2, 2, 2],
line 165:)

Under "def pretty_size(num):"
line 171:    if num > 1:
line 172:        exponent = min(int(log(num, 1024)), len(unit_list) - 1)

With the Python 3 environment this raises a TypeError exception because
zip object has no len(). With Python 2 unit_list is a list anyways.

So I explicitly created the list object on line 162 so it will work in both
line 162:unit_list = list(zip(
line 163:        ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'],
line 164:        [0, 0, 1, 2, 2, 2],
line 165:))