### PR TITLE
login check: call function directly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+2.3.3 (unreleased)
+------------------
+
+* Make login status check more resilient by not relying on its own executable to be findable in `PATH`
+
+
 2.3.2 (2016-07-05)
 ------------------
 

--- a/aldryn_client/check_system.py
+++ b/aldryn_client/check_system.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 import click
 
-from . import messages
+from . import cloud
 from . import utils
 
 ERROR = 1
@@ -57,10 +57,12 @@ class Check(object):
 
 class LoginCheck(Check):
     name = 'Login'
-    command = ('aldryn', 'login', '--check')
 
-    def fmt_exception(self, exc):
-        return [messages.LOGIN_CHECK_ERROR]
+    def run_check(self):
+        client = cloud.CloudClient(cloud.get_endpoint())
+        success, msg = client.check_login_status()
+        if not success:
+            return [msg]
 
 
 class GitCheck(Check):


### PR DESCRIPTION
`aldryn doctor -c 'login'` will now call the function directly rather than depending on the binary of ``aldryn`` being available in ``PATH``. Fixes issues with systems where the executable ``aldryn`` may be named differently or cannot be found