### PR TITLE
project update detecs git branch

### DIFF
--- a/aldryn_client/cli.py
+++ b/aldryn_client/cli.py
@@ -19,7 +19,7 @@ from .check_system import check_requirements, check_requirements_human
 from .utils import (
     hr, table, open_project_cloud_site, get_dashboard_url,
     get_project_cheatsheet_url, get_latest_version_from_pypi,
-    get_git_commit,
+    get_git_commit, get_git_checked_branch
 )
 from .validators.addon import validate_addon
 from .validators.boilerplate import validate_boilerplate
@@ -200,7 +200,7 @@ def project_open(obj):
 @click.pass_obj
 def project_update(obj):
     """Update project with latest changes from the Cloud"""
-    localdev.update_local_project()
+    localdev.update_local_project(get_git_checked_branch())
 
 
 @project.command(name='test')

--- a/aldryn_client/localdev/main.py
+++ b/aldryn_client/localdev/main.py
@@ -596,12 +596,12 @@ def push_media(client, stage):
     click.echo(' [{}s]'.format(int(time() - start_time)))
 
 
-def update_local_project():
+def update_local_project(git_branch):
     project_home = utils.get_project_home()
     docker_compose = utils.get_docker_compose_cmd(project_home)
 
     click.secho('Pulling changes from git remote', fg='green')
-    check_call(('git', 'pull'))
+    check_call(('git', 'pull', 'origin', git_branch))
     click.secho('Pulling docker images', fg='green')
     check_call(docker_compose('pull'))
     click.secho('Building local docker images', fg='green')

--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -2,8 +2,10 @@ import subprocess
 import platform
 import tarfile
 import tempfile
+
 import os
 import sys
+from subprocess import CalledProcessError
 from contextlib import contextmanager
 from distutils.version import StrictVersion
 from math import log
@@ -14,6 +16,9 @@ from tabulate import tabulate
 from six.moves.urllib_parse import urljoin
 
 from . import __version__
+
+
+ALDRYN_DEFUALT_BRANCH_NAME = "develop"
 
 
 def hr(char='-', width=None, **kwargs):
@@ -229,6 +234,20 @@ def get_git_commit():
             ]).strip()
         except:
             pass
+
+
+def get_git_checked_branch():
+    try:
+        git_branch_output = subprocess.check_output(['git', 'branch'])
+    except CalledProcessError:
+        git_branch_output = None
+
+    aldryn_branch = [branch for branch in git_branch_output.split('\n') if branch.startswith('* ')]
+
+    if aldryn_branch:
+        return aldryn_branch[0][2:]
+    else:
+        return ALDRYN_DEFUALT_BRANCH_NAME
 
 
 def get_user_agent():

--- a/aldryn_client/utils.py
+++ b/aldryn_client/utils.py
@@ -18,7 +18,7 @@ from six.moves.urllib_parse import urljoin
 from . import __version__
 
 
-ALDRYN_DEFUALT_BRANCH_NAME = "develop"
+ALDRYN_DEFAULT_BRANCH_NAME = "develop"
 
 
 def hr(char='-', width=None, **kwargs):
@@ -238,16 +238,9 @@ def get_git_commit():
 
 def get_git_checked_branch():
     try:
-        git_branch_output = subprocess.check_output(['git', 'branch'])
+        return subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
     except CalledProcessError:
-        git_branch_output = None
-
-    aldryn_branch = [branch for branch in git_branch_output.split('\n') if branch.startswith('* ')]
-
-    if aldryn_branch:
-        return aldryn_branch[0][2:]
-    else:
-        return ALDRYN_DEFUALT_BRANCH_NAME
+        return ALDRYN_DEFAULT_BRANCH_NAME
 
 
 def get_user_agent():


### PR DESCRIPTION
Added a utils method which very naively gets the current HEAD branch so that `aldryn project update` can work not only on the `develop` branch